### PR TITLE
CowieCLI now ensure only one value for populated fields

### DIFF
--- a/src/CommandInfo.bf
+++ b/src/CommandInfo.bf
@@ -11,6 +11,11 @@ namespace CowieCLI
 
 		public int RequiredOptions;
 
+		public this (StringView name)
+		{
+			Name.Set(name);
+		}
+
 		public Self Name(StringView name)
 		{
 			Name.Set(name);

--- a/src/CowieCLI.bf
+++ b/src/CowieCLI.bf
@@ -162,7 +162,11 @@ namespace CowieCLI
 			switch (field.FieldType)
 			{
 			case typeof(String):
-				res = field.SetValue(command, values[0]);
+				var fValue = field.GetValue(command).Value;
+				if (fValue.HasValue)
+					fValue.Dispose();
+
+				res = field.SetValue(command, new String(values[0]));
 				break;
 			case typeof(int):
 				var value = Int.Parse(values[0]);


### PR DESCRIPTION
Also, brought back a constructor which allows for setting the CommandInfo name